### PR TITLE
New timeout flag and metric

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -51,7 +51,7 @@ func NewExporter(ipmiBinary string, timeout int) *Exporter {
 	}
 }
 
-func ipmiOutput(cmd string, timeout int) (res IpmiResult, err error) {
+func ipmiOutput(cmd string, timeout int) (IpmiResult, error) {
 	parts := strings.Fields(cmd)
 	var out []byte
 	var err error

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -46,4 +46,11 @@ var (
 		[]string{"PSU"},
 		nil,
 	)
+
+	exectime = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "exec_time"),
+		"How much time in milliseconds was spent executing ipmitools",
+		nil,
+		nil,
+	)
 )

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	metricsPath   = flag.String("web.path", "/metrics", "Path under which to expose metrics.")
 	ipmiBinary    = flag.String("ipmi.path", "ipmitool", "Path to the ipmi binary")
 	showVersion   = flag.Bool("version", false, "Show version information and exit")
+	timeout       = flag.Int("ipmi.timeout", -1, "How many milliseconds to allow ipmitools to run before cancelling.")
 )
 
 func init() {
@@ -36,7 +37,7 @@ func main() {
 	log.Infoln("Starting IPMI Exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())
 
-	prometheus.MustRegister(collector.NewExporter(*ipmiBinary))
+	prometheus.MustRegister(collector.NewExporter(*ipmiBinary, *timeout))
 
 	handler := promhttp.Handler()
 	if *metricsPath == "" || *metricsPath == "/" {


### PR DESCRIPTION
Added a timeout flag to limit IPMI tool execution so that the IPMI tool never gets stuck running forever like in this issue where BMC stops responding (#31). Also added an IPMI execution time metric that shows how long it takes for ipmitool to execute each time the exporter is queried.